### PR TITLE
Update to v1.1.2

### DIFF
--- a/com.cuperino.qprompt.json
+++ b/com.cuperino.qprompt.json
@@ -1,7 +1,7 @@
 {
    "id": "com.cuperino.qprompt",
    "runtime": "org.kde.Platform",
-   "runtime-version": "5.15-21.08",
+   "runtime-version": "5.15-22.08",
    "sdk": "org.kde.Sdk",
    "command": "qprompt",
    "finish-args": [
@@ -40,8 +40,8 @@
             {
                "type": "git",
                "url": "https://github.com/Cuperino/QPrompt.git",
-               "tag": "v1.1.1-flatpak",
-               "commit": "b154fb52ad36216d2c4cc26c87fa6316bd8c98eb"
+               "tag": "v1.1.2-flatpak",
+               "commit": "274a823f4b7268c29b95cba8649e0dbdb6b61fee"
             }
          ]
       }


### PR DESCRIPTION
This point release adds translation to Portuguese (BR), drastically improves the performance of screen projections, and adds an option to fully disable background transparency, improving performance even further.  Apart from these changes, I've increased the runtime version number to keep up to date with the latest KDE runtimes. I've yet to test how it works with this runtime, but having kept up to date with KDE Frameworks in development I have no reason to believe it wouldn't work. As usual, all Flathub builds will be thoroughly tested prior to release.