### PR TITLE
Bump QPrompt to v2.0.2

### DIFF
--- a/com.cuperino.qprompt.json
+++ b/com.cuperino.qprompt.json
@@ -1,7 +1,7 @@
 {
    "id": "com.cuperino.qprompt",
    "runtime": "org.kde.Platform",
-   "runtime-version": "6.10",
+   "runtime-version": "6.9",
    "sdk": "org.kde.Sdk",
    "command": "qprompt",
    "finish-args": [

--- a/com.cuperino.qprompt.json
+++ b/com.cuperino.qprompt.json
@@ -59,8 +59,8 @@
             {
                "type": "git",
                "url": "https://github.com/Cuperino/QPrompt.git",
-               "tag": "v2.0.1",
-               "commit": "5925335bc0f5f84944e0a6379812b6a2538a5464"
+               "tag": "v2.0.2",
+               "commit": "dcf769fc891abcdb1d4a4b30f881e1113bf64bcc"
             }
          ]
       }

--- a/com.cuperino.qprompt.json
+++ b/com.cuperino.qprompt.json
@@ -1,7 +1,7 @@
 {
    "id": "com.cuperino.qprompt",
    "runtime": "org.kde.Platform",
-   "runtime-version": "6.9",
+   "runtime-version": "6.10",
    "sdk": "org.kde.Sdk",
    "command": "qprompt",
    "finish-args": [


### PR DESCRIPTION
We use semantic versioning. This is a bump to an update containing only bug fixes.